### PR TITLE
feat: 3.0.18 新增 qqGuildv2 指名适配

### DIFF
--- a/OlivaDiceOdyssey/app.json
+++ b/OlivaDiceOdyssey/app.json
@@ -4,8 +4,8 @@
     "namespace" : "OlivaDiceOdyssey",
     "message_mode" : "old_string",
     "info" : "本模块为OlivaDice的高阶模块，提供了一些涉及第三方合作的功能，它们或许是调用了第三方数据库，要么是涉及版权授权，又或者是单纯的过于依赖网络，总之这些功能由于第三方的参与很可能无法由插件开发者保证可靠性，但仍然很强大。例如魔都模组功能。",
-    "version" : "3.0.16",
-    "svn" : 17,
+    "version" : "3.0.18",
+    "svn" : 19,
     "compatible_svn" : 190,
     "priority" : 20040,
     "support" : [

--- a/OlivaDiceOdyssey/data.py
+++ b/OlivaDiceOdyssey/data.py
@@ -14,8 +14,8 @@ _  / / /_  /  __  / __ | / /__  /| |_  / / /__  / _  /    __  __/
 @Desc      :   None
 """
 
-OlivaDiceOdyssey_ver = '3.0.16'
-OlivaDiceOdyssey_svn = 17
+OlivaDiceOdyssey_ver = '3.0.18'
+OlivaDiceOdyssey_svn = 19
 OlivaDiceOdyssey_ver_short = '%s(%s)' % (str(OlivaDiceOdyssey_ver), str(OlivaDiceOdyssey_svn))
 
 gProc = None

--- a/OlivaDiceOdyssey/msgReply.py
+++ b/OlivaDiceOdyssey/msgReply.py
@@ -60,6 +60,10 @@ def unity_reply(plugin_event, Proc):
         if plugin_event.data.extend['sub_self_id'] is not None:
             tmp_at_str_sub = OlivOS.messageAPI.PARA.at(plugin_event.data.extend['sub_self_id']).CQ()  # NOQA: F841
             tmp_id_str_sub = str(plugin_event.data.extend['sub_self_id'])
+    tmp_id_str_sub_open = None
+    if 'sub_self_open_id' in plugin_event.data.extend:
+        if plugin_event.data.extend['sub_self_open_id'] is not None:
+            tmp_id_str_sub_open = str(plugin_event.data.extend['sub_self_open_id'])
     tmp_command_str_1 = '.'  # NOQA: F841
     tmp_command_str_2 = '。'  # NOQA: F841
     tmp_command_str_3 = '/'  # NOQA: F841
@@ -94,6 +98,8 @@ def unity_reply(plugin_event, Proc):
         if tmp_id_str in tmp_at_list:
             flag_force_reply = True
         if tmp_id_str_sub in tmp_at_list:
+            flag_force_reply = True
+        if tmp_id_str_sub_open in tmp_at_list:
             flag_force_reply = True
         if 'all' in tmp_at_list:
             flag_force_reply = True


### PR DESCRIPTION
## Summary by Sourcery

Update OlivaDiceOdyssey to version 3.0.18 and enhance mention handling for qqGuild v2 open IDs in message replies.

New Features:
- Support force-reply triggering when qqGuild v2 sub account open IDs are mentioned in messages.

Chores:
- Bump OlivaDiceOdyssey module version and SVN metadata to 3.0.18/19.